### PR TITLE
Remove VersionEye badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ implementing the PSR-3 logging standard. To achieve true interoperability, your 
 library implementing the PSR-3 logging standard.
 
 [![Build Status](https://travis-ci.org/bitExpert/slf4psrlog.svg?branch=master)](https://travis-ci.org/bitExpert/slf4psrlog)
-[![Dependency Status](https://www.versioneye.com/user/projects/57d9b5361b70a7003aae980c/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/57d9b5361b70a7003aae980c)
 [![Coverage Status](https://coveralls.io/repos/github/bitExpert/slf4psrlog/badge.svg?branch=master)](https://coveralls.io/github/bitExpert/slf4psrlog?branch=master)
 
 Installation


### PR DESCRIPTION
Remove the VersionEye badge from the readme file due to versioneye shutting down end of 2017.

More information about the VersionEye sunset process:
https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/
